### PR TITLE
cache enhancement to dfdl firestore example 

### DIFF
--- a/pubsub_firestore_binary_processor/README.md
+++ b/pubsub_firestore_binary_processor/README.md
@@ -22,6 +22,8 @@ applies the definition and publishes the json result to a topic in pubsub.
                    ├── DfdlService # Processes the binary using a dfdl definition and output a json
                    ├── FirestoreService # Reads dfdl definitons from a firestore database
                    ├── MessageController # Publishes message to a topic with a binary to be processed.
+                   ├── Processor # Allows cachaching abstraction in Spring for the DataProcessor. 
+                   ├── ProcessorDataService # Helper class to enable cachaching abstraction in Spring 
                    ├── ProcessorService # Initializes components, configurations and services.
                    ├── PubSubServer # Publishes and subscribes to topics using channels adapters.
                    └── README.md

--- a/pubsub_firestore_binary_processor/pom.xml
+++ b/pubsub_firestore_binary_processor/pom.xml
@@ -38,12 +38,7 @@ limitations under the License. -->
     <dependency>
       <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
       <groupId>com.google.cloud</groupId>
-      <version>3.1.0</version>
-    </dependency>
-    <dependency>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <groupId>org.springframework.boot</groupId>
-      <scope>test</scope>
+      <version>3.2.1</version>
     </dependency>
     <dependency>
       <artifactId>spring-boot-starter-web</artifactId>
@@ -65,13 +60,9 @@ limitations under the License. -->
       <version>3.1.0</version>
     </dependency>
     <dependency>
-      <artifactId>google-cloud-bigtable</artifactId>
-      <groupId>com.google.cloud</groupId>
-    </dependency>
-    <dependency>
       <artifactId>spring-boot</artifactId>
       <groupId>org.springframework.boot</groupId>
-      <version>2.6.5</version>
+      <version>2.6.6</version>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/pubsub_firestore_binary_processor/src/main/java/com/example/dfdl/Processor.java
+++ b/pubsub_firestore_binary_processor/src/main/java/com/example/dfdl/Processor.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.dfdl;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import org.apache.daffodil.japi.Compiler;
+import org.apache.daffodil.japi.Daffodil;
+import org.apache.daffodil.japi.DataProcessor;
+import org.apache.daffodil.japi.Diagnostic;
+import org.apache.daffodil.japi.InvalidUsageException;
+import org.apache.daffodil.japi.ProcessorFactory;
+import org.apache.daffodil.japi.ValidationMode;
+import org.apache.daffodil.japi.debugger.TraceDebuggerRunner;
+import org.springframework.beans.factory.annotation.Value;
+
+public class Processor {
+
+  @Value("${debugger.usage:true}")
+  boolean debuggerUsage;
+
+  private String definition;
+  private String name;
+
+  public Processor(String name, String definition) {
+    this.name = name;
+    this.definition = definition;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDefinition() {
+    return definition;
+  }
+
+  public void setDefinition(String definition) {
+    this.definition = definition;
+  }
+
+  DataProcessor getDataProcessor() throws IOException, InvalidUsageException {
+    System.out.println("Enter - Data Processor no in processors cached");
+    // DFDL definition file
+    File schemaFile = createSchemaFile(name, definition);
+
+    // Compile the de DFDL definition or schema file
+    Compiler dfdlCompiler = Daffodil.compiler();
+    ProcessorFactory processorFactory = dfdlCompiler.compileFile(schemaFile);
+    if (processorFactory.isError()) {
+      // Error compiling the schema. Printing diagnostic for troubleshooting.
+      List<Diagnostic> diags = processorFactory.getDiagnostics();
+      for (Diagnostic d : diags) {
+        System.err.println(d.getSomeMessage());
+      }
+      System.exit(1);
+    }
+    // "/" in the only support path.
+    DataProcessor dataProcessor =
+        processorFactory
+            .onPath("/")
+            .withValidationMode(ValidationMode.Off)
+            .withDebuggerRunner(new TraceDebuggerRunner())
+            .withDebugging(debuggerUsage);
+    return dataProcessor;
+  }
+
+  private File createSchemaFile(String name, String definition) throws IOException {
+    File schemaFile = new File(name);
+    FileWriter definitionWriter = new FileWriter(schemaFile);
+    definitionWriter.write(definition);
+    definitionWriter.close();
+    return schemaFile;
+  }
+}

--- a/pubsub_firestore_binary_processor/src/main/java/com/example/dfdl/ProcessorDataService.java
+++ b/pubsub_firestore_binary_processor/src/main/java/com/example/dfdl/ProcessorDataService.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.dfdl;
+
+import java.io.IOException;
+import org.apache.daffodil.japi.DataProcessor;
+import org.apache.daffodil.japi.InvalidUsageException;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessorDataService {
+
+  /** Returns a {@link DataProcessor} only if it doesn't find it the cache - processors. */
+  @Cacheable(value = "processors", key = "#processor.name")
+  public DataProcessor getDataProcessor(Processor processor)
+      throws IOException, InvalidUsageException {
+    return processor.getDataProcessor();
+  }
+}

--- a/pubsub_firestore_binary_processor/src/main/java/com/example/dfdl/ProcessorService.java
+++ b/pubsub_firestore_binary_processor/src/main/java/com/example/dfdl/ProcessorService.java
@@ -18,11 +18,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 
-/** Initializes components, configurations and services. */
+/**
+ * Initializes components, caching, configurations and services.
+ */
 @SpringBootApplication
+// The @EnableCaching annotation triggers a post-processor that inspects every Spring bean for
+// the presence of caching annotations on public methods. If such an annotation is found, a proxy
+// is automatically created to intercept the method call and handle the caching behavior accordingly
+@EnableCaching
 public class ProcessorService {
 
   @Value("${server.port}")
@@ -32,7 +42,9 @@ public class ProcessorService {
     SpringApplication.run(ProcessorService.class, args);
   }
 
-  /** Runs on start up. Retrieves all the beans that were created by the {@link ProcessorService} */
+  /**
+   * Runs on start up. Retrieves all the beans that were created by the {@link ProcessorService}
+   */
   @Bean
   public CommandLineRunner commandLineRunner(ApplicationContext ctx) {
 
@@ -45,5 +57,16 @@ public class ProcessorService {
         System.out.println(beanName);
       }
     };
+  }
+
+  /**
+   * Configures cache store so that the dataProcessors are cached within processors
+   */
+  @Bean
+  public CacheManager cacheManager() {
+    SimpleCacheManager cacheManager = new SimpleCacheManager();
+    cacheManager.setCaches(Arrays.asList(
+        new ConcurrentMapCache("processors")));
+    return cacheManager;
   }
 }


### PR DESCRIPTION
- using cachaching abstraction in Spring to improve the performance of dfdl schema compilation