### PR TITLE
Update expected error messages for 3.11.0

### DIFF
--- a/hexWords/src/test/java/TestHexWords.java
+++ b/hexWords/src/test/java/TestHexWords.java
@@ -126,16 +126,12 @@ public class TestHexWords {
         assertFalse(r.isProcessingError);
         assertTrue(r.isValidationError);
         compare("<word><illegal>0</illegal></word>", r.message);
-        assertTrue(r.diags.stream().map(d -> d.getMessage() ).anyMatch( m ->
-            m.contains("Validation Error") &&
-                    m.contains("illegal")));
+        assertTrue(r.diags.stream().map(d -> d.toString() ).anyMatch( m -> m.contains("Validation Error") && m.contains("illegal")));
         r = mp.parse();
         assertFalse(r.isProcessingError);
         assertTrue(r.isValidationError);
         compare("<word><illegal>0</illegal></word>", r.message);
-        assertTrue(r.diags.stream().map(d -> d.getMessage() ).anyMatch( m ->
-                m.contains("Validation Error") &&
-                        m.contains("illegal")));
+        assertTrue(r.diags.stream().map(d -> d.toString() ).anyMatch( m -> m.contains("Validation Error") && m.contains("illegal")));
         r = mp.parse();
         assertFalse(r.isProcessingError);
         assertFalse(r.isValidationError);

--- a/hexWords/src/test/scala/TestHexWords2.scala
+++ b/hexWords/src/test/scala/TestHexWords2.scala
@@ -65,12 +65,12 @@ class TestHexWords2 () {
     assertFalse(r.isProcessingError)
     assertTrue(r.isValidationError)
     compare("<word><illegal>0</illegal></word>", r.message)
-    assertTrue(r.diags.map((d) => d.getMessage()).filter((m) => m.contains("Validation Error") && m.contains("illegal")).nonEmpty)
+    assertTrue(r.diags.map((d) => d.toString).filter((m) => m.contains("Validation Error") && m.contains("illegal")).nonEmpty)
     r = mp.parse
     assertFalse(r.isProcessingError)
     assertTrue(r.isValidationError)
     compare("<word><illegal>0</illegal></word>", r.message)
-    assertTrue(r.diags.map((d) => d.getMessage()).filter((m) => m.contains("Validation Error") && m.contains("illegal")).nonEmpty)
+    assertTrue(r.diags.map((d) => d.toString).filter((m) => m.contains("Validation Error") && m.contains("illegal")).nonEmpty)
     r = mp.parse
     assertFalse(r.isProcessingError)
     assertFalse(r.isValidationError)


### PR DESCRIPTION
Due to changes made for DAFFODIL-2948, the mode of the error, eg "Validation Error" or "Parse Error" is not included in Diagnostic.getMessage() anymore.  It is instead contained in Diagnostic.getModeName().