### PR TITLE
Fix broken exificient, parseTransform, and splitAndParse examples

### DIFF
--- a/helloWorldExificient/src/main/java/HelloWorldExificient.java
+++ b/helloWorldExificient/src/main/java/HelloWorldExificient.java
@@ -80,6 +80,11 @@ class ParseUnparseException extends Exception {
 public class HelloWorldExificient {
 
     public static void main(String[] args) throws IOException, URISyntaxException {
+        int rc = run(args);
+        System.exit(rc);
+    }
+
+    public static int run(String[] args) throws IOException, URISyntaxException {
 
     URL schemaFileURL = HelloWorldExificient.class.getResource("/helloWorld.dfdl.xsd");
     URL dataFileURL = HelloWorldExificient.class.getResource("/helloWorld.dat");
@@ -128,7 +133,7 @@ public class HelloWorldExificient {
         for (Diagnostic d : diags) {
         System.err.println(d.getSomeMessage());
         }
-        System.exit(1);
+        return 1;
     }
 
     DataProcessor dp = pf.onPath("/");
@@ -138,7 +143,7 @@ public class HelloWorldExificient {
         for (Diagnostic d : diags) {
         System.err.println(d.getSomeMessage());
         }
-        System.exit(1);
+        return 1;
     }
 
     //
@@ -155,7 +160,7 @@ public class HelloWorldExificient {
         exiFactory.setCodingMode(CodingMode.COMPRESSION);
     } catch (UnsupportedOption u) {
         System.err.println(u.getMessage());
-        System.exit(1);
+        return 1;
     }
 
     try {
@@ -164,7 +169,7 @@ public class HelloWorldExificient {
         exiFactory.setGrammars(grammar);
     } catch (EXIException e) {
         System.err.println("Error creating EXI grammar for schema aware encoding: " + e.getMessage());
-        System.exit(1);
+        return 1;
     }
 
     //
@@ -186,7 +191,7 @@ public class HelloWorldExificient {
         parseOs.close();
         parseIs.close();
         if (fatalError)
-            System.exit(1);
+            return 1;
     }
 
     byte[] exiBytes = parseOs.toByteArray();
@@ -222,7 +227,7 @@ public class HelloWorldExificient {
         transformIs.close();
         transformOs.close();
         if (fatalError)
-            System.exit(1);
+            return 1;
     }
 
     // If you need to also convert XML back into the native data format
@@ -255,7 +260,7 @@ public class HelloWorldExificient {
         unparseIs.close();
         unparseOs.close();
         if (fatalError)
-            System.exit(1);
+            return 1;
     }
 
     // if we get here, unparsing was successful.
@@ -282,6 +287,7 @@ public class HelloWorldExificient {
         System.out.print(String.format("%02X ", bi));
     }
     System.out.println("");
+    return 0;
     }
 
     public static void parseToEXI(DataProcessor dp, EXIFactory exiFactory, InputStream is, ByteArrayOutputStream os)

--- a/helloWorldExificient/src/main/resources/helloWorld.dfdl.xsd
+++ b/helloWorldExificient/src/main/resources/helloWorld.dfdl.xsd
@@ -12,7 +12,7 @@
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
 
-      <dfdl:format ref="GeneralFormat"
+      <dfdl:format ref="tns:GeneralFormat"
 		   representation="text" encoding="utf-8" lengthKind="delimited"/>
 
     </xs:appinfo>

--- a/helloWorldExificient/src/test/java/TestHelloWorldExificient.java
+++ b/helloWorldExificient/src/test/java/TestHelloWorldExificient.java
@@ -25,6 +25,7 @@ public class TestHelloWorldExificient {
     @Test
     public void testMain() throws IOException, URISyntaxException{
         String[] args = { "no args" };
-        HelloWorldExificient.main(args);
+        int rc = HelloWorldExificient.run(args);
+        Assert.assertEquals(rc, 0);
     }
 }

--- a/pairsTransform/src/main/resources/com/example/pairstransform/xsd/pairstransformParseOnly.dfdl.xsd
+++ b/pairsTransform/src/main/resources/com/example/pairstransform/xsd/pairstransformParseOnly.dfdl.xsd
@@ -49,7 +49,7 @@
 
   <group name="count">
     <sequence>
-      <element name="count" type="unsignedInt"
+      <element name="count" type="unsignedInt" dfdl:textNumberPattern="#0"
                   dfdl:terminator="%NL;"/>
     </sequence>
   </group>

--- a/pairsTransform/src/main/resources/com/example/pairstransform/xsd/pairstransformWithUnparse.dfdl.xsd
+++ b/pairsTransform/src/main/resources/com/example/pairstransform/xsd/pairstransformWithUnparse.dfdl.xsd
@@ -25,7 +25,7 @@
   <xs:element name="latLon">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="count" type="xs:unsignedInt" dfdl:terminator="%NL;"/>
+        <xs:element name="count" type="xs:unsignedInt" dfdl:terminator="%NL;" dfdl:textNumberPattern="#0"/>
         <!--
           You might want to hide this group ref using dfdl:hiddenGroupRef.
 

--- a/splitAndParse/build.sbt
+++ b/splitAndParse/build.sbt
@@ -6,7 +6,8 @@ version := "0.0.1"
 
 libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-sapi" % daffodilVersion.value,
-  "com.ibm" % "dfdl-edifact" % "0.0.1-SNAPSHOT" % "test"
+  "com.ibm" % "dfdl-edifact" % "0.0.1-SNAPSHOT" % "test",
+  "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
 )
 
 enablePlugins(DaffodilPlugin)

--- a/splitAndParse/src/main/scala/com/owlcyberdefense/SchemaCompiler.scala
+++ b/splitAndParse/src/main/scala/com/owlcyberdefense/SchemaCompiler.scala
@@ -49,7 +49,6 @@ object SchemaCompiler {
   }
 
   case class CompileFailure(diags: Seq[Diagnostic])
-    extends Exception("DFDL Schema Compile Failure") {
-    override def toString() = getMessage() + "\n" + diags.mkString("\n")
+    extends Exception("DFDL Schema Compile Failure\n" + diags.mkString("\n")) {
   }
 }

--- a/splitAndParse/src/main/scala/com/owlcyberdefense/SplitAndParse.scala
+++ b/splitAndParse/src/main/scala/com/owlcyberdefense/SplitAndParse.scala
@@ -5,7 +5,9 @@ import org.apache.daffodil.sapi.io.InputSourceDataInputStream
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.net.URL
+import scala.collection.parallel.CollectionConverters._
 import scala.xml.Node
+
 
 /**
  * A utility class that takes two DFDL schemas. One is a lightweight splitter used to separate the

--- a/splitAndParse/src/test/scala/com/owlcyberdefense/TestSplitEdifact.scala
+++ b/splitAndParse/src/test/scala/com/owlcyberdefense/TestSplitEdifact.scala
@@ -1,13 +1,14 @@
 package com.owlcyberdefense
 
-import org.apache.daffodil.util.Misc
-import org.apache.daffodil.xml.XMLUtils
+import org.apache.daffodil.lib.util.Misc
+import org.apache.daffodil.lib.xml.XMLUtils
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 import java.io.IOException
 import java.io.SequenceInputStream
 
+import scala.collection.parallel.CollectionConverters._
 
 class TestSplitEdifact () {
   var splitterSchemaFileURL = Misc.getRequiredResource("int32Prefix.dfdl.xsd").toURL

--- a/splitAndParse/src/test/scala/com/owlcyberdefense/TestSplitter.scala
+++ b/splitAndParse/src/test/scala/com/owlcyberdefense/TestSplitter.scala
@@ -1,8 +1,8 @@
 package com.owlcyberdefense
 
 
-import org.apache.daffodil.util.Misc
-import org.apache.daffodil.xml.XMLUtils
+import org.apache.daffodil.lib.util.Misc
+import org.apache.daffodil.lib.xml.XMLUtils
 import org.junit.Assert._
 import org.junit.Test
 
@@ -35,7 +35,7 @@ class TestSplitter () {
   @throws[IOException]
   def testSplitter1(): Unit = {
     val is = new ByteArrayInputStream(Misc.hex2Bytes("00 00 00 09 31 32 33 34 35".replace(" ", "")))
-    var mp = new Splitter(schemaFileURL, "message", null).toResultIterator(is)
+    var mp = new Splitter(schemaFileURL, "try", null).toResultIterator(is)
     var r = mp.next()
     assertFalse(r.isProcessingError)
     assertFalse(r.isValidationError)
@@ -47,7 +47,7 @@ class TestSplitter () {
   @throws[IOException]
   def testSplitter2(): Unit = {
     val is = new ByteArrayInputStream(Misc.hex2Bytes("00 00 00 09 31 32 33 34 35".replace(" ", "")))
-    var mp = new Splitter(schemaFileURL, "message", null)
+    var mp = new Splitter(schemaFileURL, "try", null)
     val iter = mp.toResultIterator(is)
     val Seq(r) = iter.toStream.toList
     assertFalse(r.isProcessingError)
@@ -60,7 +60,7 @@ class TestSplitter () {
   def testSplitter3(): Unit = {
     val is = new ByteArrayInputStream(
       Misc.hex2Bytes("00 00 00 09 31 32 33 34 35 00 00 00 09 31 32 33 34 35".replace(" ", "")))
-    var mp = new Splitter(schemaFileURL, "message", null)
+    var mp = new Splitter(schemaFileURL, "try", null)
     val iter = mp.toResultIterator(is)
     val Seq(r1, r2) = iter.toStream.toList
     assertFalse(r1.isProcessingError)
@@ -76,7 +76,7 @@ class TestSplitter () {
   def testSplitterBad1(): Unit = {
     val is = new ByteArrayInputStream(
       Misc.hex2Bytes("00".replace(" ", "")))
-    var mp = new Splitter(schemaFileURL, "message", null)
+    var mp = new Splitter(schemaFileURL, "try", null)
     val iter = mp.toResultIterator(is)
     val list = iter.toList
     println(list)
@@ -90,7 +90,7 @@ class TestSplitter () {
   def testSplitterBad2(): Unit = {
     val is = new ByteArrayInputStream(
       Misc.hex2Bytes("00 00".replace(" ", "")))
-    var mp = new Splitter(schemaFileURL, "message", null)
+    var mp = new Splitter(schemaFileURL, "try", null)
     val iter = mp.toResultIterator(is)
     val list = iter.toList
     println(list)


### PR DESCRIPTION
HelloWorldExificient
- Change the "main" function to a "run" function so that it returns an error code instead of exiting--exiting caused sbt to shutdown if a test failed. A new main function is added that calls "run" and exits with the return integer to maintain the old behavior
- Specify the correct namespace when referencing GeneralFormat--older versions of Daffodil were too lax and did not require the namespace but newer versions require correct schemas

ParseTransform
- Change schema so 'count' has a pattern that does not add a decimals. Older versions of Daffodil would not add decimals for integers numbers even if the pattern specified decimals. Daffodil now strictly follows the pattern, so even integer numbers will be unparsed with decimals. This is not expected for this schema, so a different pattern is needed.

SplitAndParse
- Scala 2.13 and newer (which newer versions of Daffodil use) requires manually adding the scala-parallel-collections library and imports in order to use parallel collections.
- Improve the CompileFailure exception to include diags, by default sbt test failures only show the message of an exception so it it hard to see what actually failed
- Fix imports to use newer OSGI package names
- Fix tests to use the correct "try" root element. "message" is child of a complex type and is not a root element, it was likely a bug that this ever worked