### PR TITLE
Prepare to tag commit for daf-3.x

### DIFF
--- a/helloWorld/build.sbt
+++ b/helloWorld/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-helloworld"
 
 organization := "com.tresys"
 
-version := "0.1.0"
+version := "0.1.1"
 
 // People use this project to study what the dependencies actually are needed
 // so having them put into lib_managed is helpful.
@@ -10,6 +10,8 @@ retrieveManaged := true
 useCoursier := false // Workaround becauuse retrieveManaged doesn't work in some sbt versions.
 
 Compile / run / mainClass := Some("HelloWorld")
+
+daffodilVersion := "3.11.0"
 
 libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-japi" % daffodilVersion.value,

--- a/helloWorldExificient/build.sbt
+++ b/helloWorldExificient/build.sbt
@@ -2,13 +2,15 @@ name := "dfdl-helloworldexificient"
 
 organization := "com.owlcyberdefense"
 
-version := "0.1.0"
+version := "0.1.1"
 
 // People use this project to study what the dependencies actually are needed
 // so having them put into lib_managed is helpful.
 retrieveManaged := true
 
 Compile / run / mainClass := Some("HelloWorldExificient")
+
+daffodilVersion := "3.11.0"
 
 libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-japi" % daffodilVersion.value,

--- a/hexWords/build.sbt
+++ b/hexWords/build.sbt
@@ -2,7 +2,9 @@ name := "dfdl-hexWords"
 
 organization := "com.owlcyberdefense"
 
-version := "0.0.1"
+version := "0.0.2"
+
+daffodilVersion := "3.11.0"
 
 libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-sapi" % daffodilVersion.value,

--- a/pairsTransform/build.sbt
+++ b/pairsTransform/build.sbt
@@ -2,6 +2,8 @@ name := "dfdl-pairs-transform"
 
 organization := "com.example"
 
-version := "0.1.0-SNAPSHOT"
+version := "0.1.1-SNAPSHOT"
+
+daffodilVersion := "3.11.0"
 
 enablePlugins(DaffodilPlugin)

--- a/pubsub_bigtable_binary_processor_with_debugger/pom.xml
+++ b/pubsub_bigtable_binary_processor_with_debugger/pom.xml
@@ -26,7 +26,7 @@ limitations under the License. -->
   </parent>
   <groupId>com.example</groupId>
   <artifactId>mfol</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <name>mfol</name>
   <description>Demo project</description>
   <properties>
@@ -75,8 +75,8 @@ limitations under the License. -->
     </dependency>
     <dependency>
       <groupId>org.apache.daffodil</groupId>
-      <artifactId>daffodil-japi_2.12</artifactId>
-      <version>3.1.0</version>
+      <artifactId>daffodil-japi_2.13</artifactId>
+      <version>3.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/pubsub_firestore_binary_processor/pom.xml
+++ b/pubsub_firestore_binary_processor/pom.xml
@@ -37,9 +37,9 @@ limitations under the License. -->
       <groupId>org.springframework.boot</groupId>
     </dependency>
     <dependency>
-      <artifactId>daffodil-japi_2.12</artifactId>
+      <artifactId>daffodil-japi_2.13</artifactId>
       <groupId>org.apache.daffodil</groupId>
-      <version>3.3.0</version>
+      <version>3.11.0</version>
     </dependency>
     <dependency>
       <artifactId>spring-cloud-gcp-starter-data-firestore</artifactId>
@@ -83,5 +83,5 @@ limitations under the License. -->
     <java.version>11</java.version>
   </properties>
 
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
 </project>

--- a/selfDescriptiveData/build.sbt
+++ b/selfDescriptiveData/build.sbt
@@ -2,12 +2,14 @@ name := "dfdl-self-descriptive-data"
 
 organization := "com.tresys"
 
-version := "0.1.0"
+version := "0.1.1"
 
 Compile / run / mainClass := Some("com.tresys.tscv.TypedCSV")
 
+daffodilVersion := "3.11.0"
+
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-japi" % daffodilVersion.value,
+  "org.apache.daffodil" %% "daffodil-japi" % daffodilVersion.value
 )
 
 enablePlugins(DaffodilPlugin)

--- a/splitAndParse/build.sbt
+++ b/splitAndParse/build.sbt
@@ -2,7 +2,9 @@ name := "splitAndParse"
 
 organization := "com.owlcyberdefense"
 
-version := "0.0.1"
+version := "0.0.2"
+
+daffodilVersion := "3.11.0"
 
 libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-sapi" % daffodilVersion.value,

--- a/superexp/build.sbt
+++ b/superexp/build.sbt
@@ -2,7 +2,9 @@ name := "dfdl-superexp"
 
 organization := "com.example"
 
-version := "0.1.0-SNAPSHOT"
+version := "0.1.1-SNAPSHOT"
+
+daffodilVersion := "3.11.0"
 
 enablePlugins(DaffodilPlugin)
 

--- a/superexp/test/TestSuperexp.scala
+++ b/superexp/test/TestSuperexp.scala
@@ -1,9 +1,10 @@
 package com.example.superexp
 
-import org.junit.AfterClass
-import org.junit.Test
-
 import org.apache.daffodil.tdml.Runner
+
+import org.junit.AfterClass
+import org.junit.Ignore
+import org.junit.Test
 
 object TestSuperexp {
   lazy val runner = Runner("/", "TestSuperexp.tdml")
@@ -27,9 +28,10 @@ class TestSuperexp {
 
   @Test def test_superexp_5(): Unit = { runner.runOneTest("test_superexp_5") }
 
+  @Ignore("Gets out of memory in java heap unless run with sbt -J-Xmx3g test")
   @Test def test_superexp_6(): Unit = { runner.runOneTest("test_superexp_6") }
 
-  // Gets out of memory in java heap even when run with sbt -J-Xmx48g test
-  // @Test def test_superexp_7(): Unit = { runner.runOneTest("test_superexp_7") }
+  @Ignore("Gets out of memory in java heap even when run with sbt -J-Xmx48g test")
+  @Test def test_superexp_7(): Unit = { runner.runOneTest("test_superexp_7") }
 
 }

--- a/xslt-csv/build.sbt
+++ b/xslt-csv/build.sbt
@@ -2,13 +2,15 @@ name := "dfdl-xslt-csv"
 
 organization := "com.example"
 
-version := "0.0.2"
+version := "0.0.3"
+
+daffodilVersion := "3.11.0"
 
 libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-japi" % daffodilVersion.value,
   "xalan" % "xalan" % "2.7.3",
   "xalan" % "serializer" % "2.7.3",
-  "commons-io" % "commons-io" % "2.16.1" % Test,
+  "commons-io" % "commons-io" % "2.16.1" % Test
 )
 
 enablePlugins(DaffodilPlugin)


### PR DESCRIPTION
- splitAndParse dependencies requires at least scala 2.13, but the default daffodil version is 3.10, which doesn't have a 2.13 release, so we change the daffodil and scala version for that project